### PR TITLE
Fix newest entries missing

### DIFF
--- a/lib/components/display_interval_picker.dart
+++ b/lib/components/display_interval_picker.dart
@@ -27,9 +27,7 @@ class IntervalPicker extends StatelessWidget {
           intervallDisplayText = DateFormat.y(AppLocalizations.of(context)!.localeName).format(settings.displayDataStart);
           break;
         case TimeStep.lifetime:
-          // TODO revert after testing
-          intervallDisplayText = settings.displayDataStart.toIso8601String() +  ' - ' + settings.displayDataEnd.toIso8601String();
-          // intervallDisplayText =  '-';
+          intervallDisplayText =  '-';
           break;
         case TimeStep.last7Days:
         case TimeStep.last30Days:

--- a/lib/components/display_interval_picker.dart
+++ b/lib/components/display_interval_picker.dart
@@ -27,7 +27,9 @@ class IntervalPicker extends StatelessWidget {
           intervallDisplayText = DateFormat.y(AppLocalizations.of(context)!.localeName).format(settings.displayDataStart);
           break;
         case TimeStep.lifetime:
-          intervallDisplayText =  '-';
+          // TODO revert after testing
+          intervallDisplayText = settings.displayDataStart.toIso8601String() +  ' - ' + settings.displayDataEnd.toIso8601String();
+          // intervallDisplayText =  '-';
           break;
         case TimeStep.last7Days:
         case TimeStep.last30Days:

--- a/lib/model/ram_only_implementations.dart
+++ b/lib/model/ram_only_implementations.dart
@@ -541,6 +541,11 @@ class RamSettings extends ChangeNotifier implements Settings {
     displayDataStart = newInterval[0];
     displayDataEnd = newInterval[1];
   }
+  
+  @override
+  void setToMostRecentIntervall() {
+    changeStepSize(graphStepSize);
+  }
 
   @override
   void moveDisplayDataByStep(int directionalStep) {
@@ -566,7 +571,7 @@ class RamSettings extends ChangeNotifier implements Settings {
         break;
       case TimeStep.lifetime:
         displayDataStart = DateTime.fromMillisecondsSinceEpoch(1);
-        displayDataEnd = DateTime.now();
+        displayDataEnd = DateTime.now().copyWith(hour: 23, minute: 59, second: 59);
         break;
       case TimeStep.last30Days:
         displayDataStart = oldStart.copyWith(day: oldStart.day + directionalStep * 30);
@@ -598,15 +603,18 @@ class RamSettings extends ChangeNotifier implements Settings {
         return [start, start.copyWith(year: now.year + 1)];
       case TimeStep.lifetime:
         final start = DateTime.fromMillisecondsSinceEpoch(1);
-        return [start, now];
+        final endOfToday = now.copyWith(hour: 23, minute: 59, second: 59);
+        return [start, endOfToday];
       case TimeStep.last7Days:
-        final start = now.copyWith(day: now.day-7);
-        return [start, now];
+        final start = now.copyWith(day: now.day - 7);
+        final endOfToday = now.copyWith(hour: 23, minute: 59, second: 59);
+        return [start, endOfToday];
       case TimeStep.last30Days:
-        final start = now.copyWith(day: now.day-30);
-        return [start, now];
+        final start = now.copyWith(day: now.day - 30);
+        final endOfToday = now.copyWith(hour: 23, minute: 59, second: 59);
+        return [start, endOfToday];
       case TimeStep.custom:
-        // fallback, TimeStep will be reset by getter
+      // fallback, TimeStep will be reset by getter
         return [DateTime.fromMillisecondsSinceEpoch(-1), DateTime.fromMillisecondsSinceEpoch(-1)];
     }
   }

--- a/lib/model/ram_only_implementations.dart
+++ b/lib/model/ram_only_implementations.dart
@@ -614,7 +614,7 @@ class RamSettings extends ChangeNotifier implements Settings {
         final endOfToday = now.copyWith(hour: 23, minute: 59, second: 59);
         return [start, endOfToday];
       case TimeStep.custom:
-      // fallback, TimeStep will be reset by getter
+        // fallback, TimeStep will be reset by getter
         return [DateTime.fromMillisecondsSinceEpoch(-1), DateTime.fromMillisecondsSinceEpoch(-1)];
     }
   }

--- a/lib/model/settings_store.dart
+++ b/lib/model/settings_store.dart
@@ -138,6 +138,10 @@ class Settings extends ChangeNotifier {
     displayDataEnd = newInterval[1];
   }
 
+  void setToMostRecentIntervall() {
+    changeStepSize(graphStepSize);
+  }
+
   void moveDisplayDataByStep(int directionalStep) {
     final oldStart = displayDataStart;
     final oldEnd = displayDataEnd;
@@ -161,7 +165,7 @@ class Settings extends ChangeNotifier {
         break;
       case TimeStep.lifetime:
         displayDataStart = DateTime.fromMillisecondsSinceEpoch(1);
-        displayDataEnd = DateTime.now();
+        displayDataEnd = DateTime.now().copyWith(hour: 23, minute: 59, second: 59);
         break;
       case TimeStep.last30Days:
         displayDataStart = oldStart.copyWith(day: oldStart.day + directionalStep * 30);
@@ -192,13 +196,16 @@ class Settings extends ChangeNotifier {
         return [start, start.copyWith(year: now.year + 1)];
       case TimeStep.lifetime:
         final start = DateTime.fromMillisecondsSinceEpoch(1);
-        return [start, now];
+        final endOfToday = now.copyWith(hour: 23, minute: 59, second: 59);
+        return [start, endOfToday];
       case TimeStep.last7Days:
-        final start = now.copyWith(day: now.day-7);
-        return [start, now];
+        final start = now.copyWith(day: now.day - 7);
+        final endOfToday = now.copyWith(hour: 23, minute: 59, second: 59);
+        return [start, endOfToday];
       case TimeStep.last30Days:
-        final start = now.copyWith(day: now.day-30);
-        return [start, now];
+        final start = now.copyWith(day: now.day - 30);
+        final endOfToday = now.copyWith(hour: 23, minute: 59, second: 59);
+        return [start, endOfToday];
       case TimeStep.custom:
         // fallback, TimeStep will be reset by getter
         return [DateTime.fromMillisecondsSinceEpoch(-1), DateTime.fromMillisecondsSinceEpoch(-1)];

--- a/lib/screens/add_measurement.dart
+++ b/lib/screens/add_measurement.dart
@@ -177,6 +177,8 @@ class _AddMeasurementPageState extends State<AddMeasurementPage> {
                                       await ExportConfigurationModel.get(Provider.of<Settings>(context, listen: false), localizations));
                                   exporter.export();
                                 }
+                                // ensures the most recent entry is visible when submitting a new measurement
+                                settings.setToMostRecentIntervall();
                                 navigator.pop();
                               }
                             },

--- a/lib/screens/add_measurement.dart
+++ b/lib/screens/add_measurement.dart
@@ -178,7 +178,9 @@ class _AddMeasurementPageState extends State<AddMeasurementPage> {
                                   exporter.export();
                                 }
                                 // ensures the most recent entry is visible when submitting a new measurement
-                                settings.setToMostRecentIntervall();
+                                if (settings.graphStepSize != TimeStep.custom) {
+                                  settings.setToMostRecentIntervall();
+                                }
                                 navigator.pop();
                               }
                             },


### PR DESCRIPTION
To avoid missing new entries the display time frame is now forcefully reset to the newest date after adding a measurement.
