### PR TITLE
fix graph labels

### DIFF
--- a/lib/components/measurement_graph.dart
+++ b/lib/components/measurement_graph.dart
@@ -22,7 +22,7 @@ class _LineChart extends StatefulWidget {
 }
 
 class _LineChartState extends State<_LineChart> {
-  double _lineChartTitleIntervall = 100000000;
+  double _lineChartTitleIntervall = 100000000; // TODO: remove settings as well
   int _reloadsLeft = 30;
 
   @override
@@ -34,8 +34,7 @@ class _LineChartState extends State<_LineChart> {
             return Consumer<BloodPressureModel>(builder: (context, model, child) {
               var end = settings.displayDataEnd;
               return ConsistentFutureBuilder<UnmodifiableListView<BloodPressureRecord>>(
-                  future: (settings.graphStepSize == TimeStep.lifetime) ? model.all
-                      : model.getInTimeRange(settings.displayDataStart, end),
+                  future: model.getInTimeRange(settings.displayDataStart, end),
                   onData: (context, fetchedData) {
                     List<BloodPressureRecord> data = fetchedData.toList();
                     data.sort((a, b) => a.creationTime.compareTo(b.creationTime));
@@ -80,8 +79,9 @@ class _LineChartState extends State<_LineChart> {
                           LineChartData(
                               minY: minValue.toDouble(),
                               maxY: maxValue + 5,
-                              clipData: FlClipData.all(),
-                              titlesData: _buildFlTitlesData(settings),
+                              clipData: const FlClipData.all(),
+                              titlesData: _buildFlTitlesData(settings,
+                                  DateTimeRange(start: data.first.creationTime, end: data.last.creationTime)),
                               lineTouchData: const LineTouchData(
                                   touchTooltipData: LineTouchTooltipData(tooltipMargin: -200, tooltipRoundedRadius: 20)
                               ),
@@ -119,7 +119,7 @@ class _LineChartState extends State<_LineChart> {
     return bars;
   }
 
-  FlTitlesData _buildFlTitlesData(Settings settings) {
+  FlTitlesData _buildFlTitlesData(Settings settings, DateTimeRange graphRange) {
     const noTitels = AxisTitles(sideTitles: SideTitles(reservedSize: 40, showTitles: false));
     return FlTitlesData(
       topTitles: noTitels,
@@ -127,21 +127,8 @@ class _LineChartState extends State<_LineChart> {
       bottomTitles: AxisTitles(
         sideTitles: SideTitles(
           showTitles: true,
-          interval: _lineChartTitleIntervall,
-          getTitlesWidget: (double pos, TitleMeta meta) {
-            // calculate new intervall
-            // as graphWidth can technically be as low as one max is needed here to avoid freezes
-            double graphWidth = meta.max - meta.min;
-            if ((max(graphWidth - 2,1) / settings.graphTitlesCount) != _lineChartTitleIntervall && (_reloadsLeft > 0)) {
-              // simple hack needed to change the state during build https://stackoverflow.com/a/63607696/21489239
-              Future.delayed(Duration.zero, () async {
-                setState(() {
-                  _reloadsLeft--;
-                  _lineChartTitleIntervall = max(graphWidth - 2,1) / settings.graphTitlesCount;
-                });
-              });
-            }
 
+          getTitlesWidget: (double pos, TitleMeta meta) {
             // don't show fixed titles, as they are replaced by long dates below
             if (meta.axisPosition <= 1 || pos >= meta.max) {
               return const SizedBox.shrink();
@@ -149,29 +136,20 @@ class _LineChartState extends State<_LineChart> {
 
             // format of titles
             late final DateFormat formatter;
-            switch (settings.graphStepSize) {
-              case TimeStep.day:
-                formatter = DateFormat('H:m');
-                break;
-              case TimeStep.month:
-              case TimeStep.last7Days:
-                formatter = DateFormat('d');
-                break;
-              case TimeStep.week:
-                formatter = DateFormat('E');
-                break;
-              case TimeStep.year:
-                formatter = DateFormat('MMM');
-                break;
-              case TimeStep.lifetime:
-                formatter = DateFormat('yyyy');
-                break;
-              case TimeStep.last30Days:
-              case TimeStep.custom:
-                formatter = DateFormat.MMMd();
+
+            if (graphRange.duration < const Duration(days: 2)) {
+              formatter = DateFormat.Hm();
+            } else if (graphRange.duration < const Duration(days: 15)) {
+              formatter = DateFormat.EEEE();
+            } else if (graphRange.duration < const Duration(days: 30)) {
+              formatter = DateFormat.d();
+            } else if (graphRange.duration < const Duration(days: 500)) {
+              formatter = DateFormat.MMM();
+            } else {
+              formatter = DateFormat.y();
             }
-            return Text(formatter
-                .format(DateTime.fromMillisecondsSinceEpoch(pos.toInt())));
+              return Text(formatter
+                  .format(DateTime.fromMillisecondsSinceEpoch(pos.toInt())));
           }
         ),
       ),

--- a/lib/components/measurement_graph.dart
+++ b/lib/components/measurement_graph.dart
@@ -22,9 +22,6 @@ class _LineChart extends StatefulWidget {
 }
 
 class _LineChartState extends State<_LineChart> {
-  double _lineChartTitleIntervall = 100000000; // TODO: remove settings as well
-  int _reloadsLeft = 30;
-
   @override
   Widget build(BuildContext context) {
     return SizedBox(

--- a/lib/components/measurement_graph.dart
+++ b/lib/components/measurement_graph.dart
@@ -127,7 +127,6 @@ class _LineChartState extends State<_LineChart> {
       bottomTitles: AxisTitles(
         sideTitles: SideTitles(
           showTitles: true,
-
           getTitlesWidget: (double pos, TitleMeta meta) {
             // don't show fixed titles, as they are replaced by long dates below
             if (meta.axisPosition <= 1 || pos >= meta.max) {
@@ -136,11 +135,10 @@ class _LineChartState extends State<_LineChart> {
 
             // format of titles
             late final DateFormat formatter;
-
             if (graphRange.duration < const Duration(days: 2)) {
               formatter = DateFormat.Hm();
             } else if (graphRange.duration < const Duration(days: 15)) {
-              formatter = DateFormat.EEEE();
+              formatter = DateFormat.E();
             } else if (graphRange.duration < const Duration(days: 30)) {
               formatter = DateFormat.d();
             } else if (graphRange.duration < const Duration(days: 500)) {
@@ -148,8 +146,9 @@ class _LineChartState extends State<_LineChart> {
             } else {
               formatter = DateFormat.y();
             }
-              return Text(formatter
-                  .format(DateTime.fromMillisecondsSinceEpoch(pos.toInt())));
+              return Text(
+                formatter.format(DateTime.fromMillisecondsSinceEpoch(pos.toInt()))
+              );
           }
         ),
       ),

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -103,8 +103,6 @@
   "@graphLineThickness": {},
   "animationSpeed": "Animation duration",
   "@animationSpeed": {},
-  "graphTitlesCount": "Graph label count",
-  "@graphTitlesCount": {},
   "accentColor": "Theme color",
   "@accentColor": {},
   "sysColor": "Systolic color",

--- a/lib/model/ram_only_implementations.dart
+++ b/lib/model/ram_only_implementations.dart
@@ -68,7 +68,6 @@ class RamSettings extends ChangeNotifier implements Settings {
   int _sysWarn = 120;
   bool _useExportCompatability = false;
   bool _validateInputs = true;
-  int _graphTitlesCount = 5;
   ExportFormat _exportFormat = ExportFormat.csv;
   String _csvFieldDelimiter = ',';
   String _csvTextDelimiter = '"';
@@ -255,15 +254,6 @@ class RamSettings extends ChangeNotifier implements Settings {
   @override
   set validateInputs(bool value) {
     _validateInputs = value;
-    notifyListeners();
-  }
-
-  @override
-  int get graphTitlesCount => _graphTitlesCount;
-
-  @override
-  set graphTitlesCount(int value) {
-    _graphTitlesCount = value;
     notifyListeners();
   }
 

--- a/lib/model/settings_store.dart
+++ b/lib/model/settings_store.dart
@@ -63,6 +63,9 @@ class Settings extends ChangeNotifier {
     if (keys.contains('iconSize')) {
       toAwait.add(_prefs.remove('iconSize'));
     }
+    if (keys.contains('titlesCount')) {
+      toAwait.add(_prefs.remove('titlesCount'));
+    }
 
     // reset variables for new version. Necessary for reusing variable names in new version and avoid having unexpected
     // breaking values in the preferences
@@ -370,15 +373,6 @@ class Settings extends ChangeNotifier {
 
   set confirmDeletion(bool confirmDeletion) {
     _prefs.setBool('confirmDeletion', confirmDeletion);
-    notifyListeners();
-  }
-
-  int get graphTitlesCount {
-    return _prefs.getInt('titlesCount') ?? 5;
-  }
-
-  set graphTitlesCount(int newCount) {
-    _prefs.setInt('titlesCount', newCount);
     notifyListeners();
   }
 

--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -114,18 +114,6 @@ class SettingsPage extends StatelessWidget {
                 end: 1000,
                 stepSize: 50,
               ),
-              SliderSettingsTile(
-                key: const Key('graphTitlesCount'),
-                title: Text(AppLocalizations.of(context)!.graphTitlesCount),
-                leading: const Icon(Icons.functions),
-                onChanged: (double value) {
-                  settings.graphTitlesCount = value.toInt();
-                },
-                initialValue: settings.graphTitlesCount.toDouble(),
-                start: 2,
-                end: 10,
-                stepSize: 1,
-              ),
               ColorSelectionSettingsTile(
                 key: const Key('sysColor'),
                 onMainColorChanged: (color) => settings.sysColor = createMaterialColor((color ?? Colors.green).value),

--- a/test/model/settings_test.dart
+++ b/test/model/settings_test.dart
@@ -40,7 +40,6 @@ void main() {
       expect(s.graphLineThickness, 3);
       expect(s.animationSpeed, 150);
       expect(s.confirmDeletion, true);
-      expect(s.graphTitlesCount, 5);
       expect(s.csvFieldDelimiter, ',');
       expect(s.csvTextDelimiter, '"');
       expect(s.exportCsvHeadline, true);
@@ -82,7 +81,6 @@ void main() {
       s.graphLineThickness = 5;
       s.animationSpeed = 100;
       s.confirmDeletion = false;
-      s.graphTitlesCount = 7;
       s.csvFieldDelimiter = '|';
       s.csvTextDelimiter = '\'';
       s.exportItemsCsv = ['systolic', 'diastolic', 'pulse', 'notes', 'isoUTCTime'];
@@ -108,7 +106,6 @@ void main() {
       expect(s.graphLineThickness, 5);
       expect(s.animationSpeed, 100);
       expect(s.confirmDeletion, false);
-      expect(s.graphTitlesCount, 7);
       expect(s.csvFieldDelimiter, '|');
       expect(s.csvTextDelimiter, '\'');
       expect(s.exportItemsCsv, ['systolic', 'diastolic', 'pulse', 'notes', 'isoUTCTime']);
@@ -145,7 +142,6 @@ void main() {
       s.graphLineThickness = 5;
       s.animationSpeed = 100;
       s.confirmDeletion = true;
-      s.graphTitlesCount = 2;
       s.csvFieldDelimiter = '|';
       s.csvTextDelimiter = '\'';
       s.exportItemsCsv = ['systolic', 'diastolic', 'pulse', 'notes', 'isoUTCTime'];
@@ -156,7 +152,7 @@ void main() {
       s.allowMissingValues = true;
       s.language = const Locale('de');
 
-      expect(i, 27);
+      expect(i, 26);
     });
   });
 
@@ -187,7 +183,6 @@ void main() {
       expect(s.graphLineThickness, 3);
       expect(s.animationSpeed, 150);
       expect(s.confirmDeletion, true);
-      expect(s.graphTitlesCount, 5);
       expect(s.csvFieldDelimiter, ',');
       expect(s.csvTextDelimiter, '"');
       expect(s.exportCsvHeadline, true);
@@ -229,7 +224,6 @@ void main() {
       s.graphLineThickness = 5;
       s.animationSpeed = 100;
       s.confirmDeletion = false;
-      s.graphTitlesCount = 7;
       s.csvFieldDelimiter = '|';
       s.csvTextDelimiter = '\'';
       s.exportItemsCsv = ['systolic', 'diastolic', 'pulse', 'notes', 'isoUTCTime'];
@@ -255,7 +249,6 @@ void main() {
       expect(s.graphLineThickness, 5);
       expect(s.animationSpeed, 100);
       expect(s.confirmDeletion, false);
-      expect(s.graphTitlesCount, 7);
       expect(s.csvFieldDelimiter, '|');
       expect(s.csvTextDelimiter, '\'');
       expect(s.exportItemsCsv, ['systolic', 'diastolic', 'pulse', 'notes', 'isoUTCTime']);
@@ -292,7 +285,6 @@ void main() {
       s.graphLineThickness = 5;
       s.animationSpeed = 100;
       s.confirmDeletion = true;
-      s.graphTitlesCount = 2;
       s.csvFieldDelimiter = '|';
       s.csvTextDelimiter = '\'';
       s.exportItemsCsv = ['systolic', 'diastolic', 'pulse', 'notes', 'isoUTCTime'];
@@ -303,7 +295,7 @@ void main() {
       s.allowMissingValues = true;
       s.language = const Locale('de');
 
-      expect(i, 27);
+      expect(i, 26);
     });
   });
 }


### PR DESCRIPTION
Fixes graph labels showing not often enough or too often, by determining the amount of times it shows up automatically.

The graph labels are now more useful as well, as they depend on the values that are actually shown. For example, the year interval is selected but only a week of data is collected, the labels give more precise information than just the month.