### PR TITLE
Avoid ConsistentFutureBuilder rebuilding

### DIFF
--- a/lib/components/consistent_future_builder.dart
+++ b/lib/components/consistent_future_builder.dart
@@ -1,7 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 
-class ConsistentFutureBuilder<T> extends StatelessWidget {
+class ConsistentFutureBuilder<T> extends StatefulWidget {
+  /// Future that gets evaluated.
+  ///
+  /// This Future is saved as a state, so the build function won't get called again when a rebuild occurs. The future
+  /// gets evaluated once.
   final Future<T> future;
   final Widget Function(BuildContext context, T result) onData;
   
@@ -12,21 +16,34 @@ class ConsistentFutureBuilder<T> extends StatelessWidget {
   const ConsistentFutureBuilder({super.key, required this.future, this.onNotStarted, this.onWaiting, this.onError, required this.onData});
 
   @override
+  State<ConsistentFutureBuilder<T>> createState() => _ConsistentFutureBuilderState<T>();
+}
+
+class _ConsistentFutureBuilderState<T> extends State<ConsistentFutureBuilder<T>> {
+  late final Future<T> _future; // avoid rebuilds
+
+  @override
+  void initState() {
+    super.initState();
+    _future = widget.future;
+  }
+
+  @override
   Widget build(BuildContext context) {
     return FutureBuilder<T>(
-      future: future,
+      future: _future,
       builder: (BuildContext context, AsyncSnapshot<T> snapshot) {
         if (snapshot.hasError) {
           return Text(AppLocalizations.of(context)!.error(snapshot.error.toString()));
         }
         switch (snapshot.connectionState) {
           case ConnectionState.none:
-            return onNotStarted ?? Text(AppLocalizations.of(context)!.errNotStarted);
+            return widget.onNotStarted ?? Text(AppLocalizations.of(context)!.errNotStarted);
           case ConnectionState.waiting:
           case ConnectionState.active:
-            return onWaiting ?? Text(AppLocalizations.of(context)!.loading);
+            return widget.onWaiting ?? Text(AppLocalizations.of(context)!.loading);
           case ConnectionState.done:
-            return onData(context, snapshot.data as T);
+            return widget.onData(context, snapshot.data as T);
         }
       });
   }

--- a/lib/components/export_item_order.dart
+++ b/lib/components/export_item_order.dart
@@ -24,14 +24,10 @@ class ExportItemsCustomizer extends StatefulWidget {
 }
 
 class _ExportItemsCustomizerState extends State<ExportItemsCustomizer> {
-  // hack so that FutureBuilder doesn't always rebuild
-  Future<ExportConfigurationModel>? _future;
-
   @override
   Widget build(BuildContext context) {
-    _future ??= ExportConfigurationModel.get(Provider.of<Settings>(context, listen: false), AppLocalizations.of(context)!);
     return ConsistentFutureBuilder(
-      future: _future!,
+      future: ExportConfigurationModel.get(Provider.of<Settings>(context, listen: false), AppLocalizations.of(context)!),
       onData: (BuildContext context, ExportConfigurationModel result) {
         return _buildAddItemBadge(context, result,
           child: _buildManagePresetsBadge(context, result,

--- a/lib/components/legacy_measurement_list.dart
+++ b/lib/components/legacy_measurement_list.dart
@@ -69,9 +69,8 @@ class LegacyMeasurementsList extends StatelessWidget {
         Expanded(
           child: Consumer<BloodPressureModel>(builder: (context, model, child) {
             return Consumer<Settings>(builder: (context, settings, child) {
-              final items = model.getInTimeRange(settings.displayDataStart, settings.displayDataEnd);
               return ConsistentFutureBuilder<UnmodifiableListView<BloodPressureRecord>>(
-                future: items,
+                future: model.getInTimeRange(settings.displayDataStart, settings.displayDataEnd),
                 onData: (context, data) {
                   if (data.isNotEmpty) {
                     return ListView.builder(

--- a/lib/screens/statistics.dart
+++ b/lib/screens/statistics.dart
@@ -10,7 +10,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:provider/provider.dart';
 
-// TODO: rewrite to be smaller is possible
 class StatisticsPage extends StatelessWidget {
   const StatisticsPage({super.key});
 

--- a/lib/screens/subsettings/export_import_screen.dart
+++ b/lib/screens/subsettings/export_import_screen.dart
@@ -178,27 +178,14 @@ class ExportImportScreen extends StatelessWidget {
   }
 }
 
-class ExportFieldCustomisationSetting extends StatefulWidget {
+class ExportFieldCustomisationSetting extends StatelessWidget {
   const ExportFieldCustomisationSetting({super.key});
-
-  @override
-  State<ExportFieldCustomisationSetting> createState() =>
-      _ExportFieldCustomisationSettingState();
-}
-
-class _ExportFieldCustomisationSettingState
-    extends State<ExportFieldCustomisationSetting> {
-  // hack so that FutureBuilder doesn't always rebuild
-  Future<ExportConfigurationModel>? _future;
 
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
-    _future ??= ExportConfigurationModel.get(
-        Provider.of<Settings>(context, listen: false), localizations);
-
     return ConsistentFutureBuilder(
-        future: _future!,
+        future: ExportConfigurationModel.get(Provider.of<Settings>(context, listen: false), localizations),
         onData: (context, configurationModel) {
           return Consumer<Settings>(builder: (context, settings, child) {
             /// whether or not the currently selected export format supports field customization
@@ -322,16 +309,13 @@ class ExportWarnBanner extends StatefulWidget {
 
 class _ExportWarnBannerState extends State<ExportWarnBanner> {
   bool _showWarnBanner = true;
-  late Future<ExportConfigurationModel> _future;
 
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
-    _future = ExportConfigurationModel.get(
-        Provider.of<Settings>(context, listen: false), localizations);
     return Consumer<Settings>(builder: (context, settings, child) {
       return ConsistentFutureBuilder(
-          future: _future,
+          future: ExportConfigurationModel.get(Provider.of<Settings>(context, listen: false), localizations),
           onData: (context, configurationModel) {
             String? message;
             final exportCustomEntries =


### PR DESCRIPTION
Some elements, like the version indicator in the settings used to flash when rebuilt. The workaround / correct implementation is now part of the general ConsistentFutureBuilder implementation.