### PR TITLE
Drop desktop support

### DIFF
--- a/lib/model/blood_pressure.dart
+++ b/lib/model/blood_pressure.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 
 import 'package:blood_pressure_app/screens/error_reporting.dart';
 import 'package:collection/collection.dart';
@@ -66,11 +65,6 @@ class BloodPressureModel extends ChangeNotifier {
   /// [dbPath] is the path to the folder the database is in. When [dbPath] is left empty the default database file is
   /// used. The [isFullPath] option tells the constructor not to add the default filename at the end of [dbPath].
   static Future<BloodPressureModel> create({String? dbPath, bool isFullPath = false}) async {
-    if (Platform.isWindows || Platform.isLinux) { // TODO: drop desktop support
-      sqfliteFfiInit();
-      databaseFactory = databaseFactoryFfi;
-    }
-
     final component = BloodPressureModel._create();
     await component._asyncInit(dbPath, isFullPath);
     return component;

--- a/lib/model/blood_pressure.dart
+++ b/lib/model/blood_pressure.dart
@@ -5,7 +5,7 @@ import 'package:blood_pressure_app/screens/error_reporting.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:path/path.dart';
-import 'package:sqflite_common_ffi/sqflite_ffi.dart';
+import 'package:sqflite/sqflite.dart';
 
 class BloodPressureModel extends ChangeNotifier {
   static const maxEntries = 2E64; // https://www.sqlite.org/limits.html Nr.13

--- a/lib/model/export_import.dart
+++ b/lib/model/export_import.dart
@@ -168,6 +168,7 @@ class ExportFileCreator {
   }
 
   pw.Widget _buildPdfTitle(DateFormat dateFormatter, BloodPressureAnalyser analyzer) {
+    if (analyzer.firstDay == null || analyzer.lastDay == null) return pw.Text(localizations.errNoData);
     return pw.Container(
       child: pw.Text(
         localizations.pdfDocumentTitle(dateFormatter.format(analyzer.firstDay!), dateFormatter.format(analyzer.lastDay!)),
@@ -281,39 +282,23 @@ class Exporter {
     var fileContents = await ExportFileCreator(settings, exportSettings, csvExportSettings, pdfExportSettings,
         localizations, theme, exportColumnsConfig).createFile(data);
     String filename = 'blood_press_${DateTime.now().toIso8601String()}';
-    String ext;
-    switch(exportSettings.exportFormat) {
-      case ExportFormat.csv:
-        ext = 'csv';
-        break;
-      case ExportFormat.pdf:
-        ext = 'pdf';
-        break;
-      case ExportFormat.db:
-        ext = 'db';
-        break;
-    }
+    String ext = exportSettings.exportFormat.name;
     String path = await FileSaver.instance.saveFile(name: filename, ext: ext, bytes: fileContents);
 
-    if (Platform.isLinux || Platform.isWindows || Platform.isMacOS) {
-      messenger.showSnackBar(SnackBar(content: Text(localizations.success(path))));
-    } else if (Platform.isAndroid || Platform.isIOS) {
-      if (exportSettings.defaultExportDir.isNotEmpty) {
-        JSaver.instance.save(
-            fromPath: path,
-            androidPathOptions: AndroidPathOptions(toDefaultDirectory: true)
-        );
-        messenger.showSnackBar(SnackBar(content: Text(localizations.success(exportSettings.defaultExportDir))));
-      } else {
-        Share.shareXFiles([
-          XFile(
-              path,
-              mimeType: MimeType.csv.type
-          )
-        ]);
-      }
+    assert(Platform.isAndroid || Platform.isIOS);
+    if (exportSettings.defaultExportDir.isNotEmpty) {
+      JSaver.instance.save(
+          fromPath: path,
+          androidPathOptions: AndroidPathOptions(toDefaultDirectory: true)
+      );
+      messenger.showSnackBar(SnackBar(content: Text(localizations.success(exportSettings.defaultExportDir))));
     } else {
-      messenger.showSnackBar(const SnackBar(content: Text('UNSUPPORTED PLATFORM')));
+      Share.shareXFiles([
+        XFile(
+            path,
+            mimeType: MimeType.csv.type
+        )
+      ]);
     }
   }
 

--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -22,13 +22,7 @@ class AppHome extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final localizations = AppLocalizations.of(context)!;
-    EdgeInsets padding;
-    if (MediaQuery.of(context).size.width < 1000) {
-      padding = const EdgeInsets.only(left: 10, right: 10, bottom: 15, top: 30);
-    } else {
-      padding = const EdgeInsets.all(80);
-    }
-
+    //
     // direct use of settings possible as no listening is required
     if (_appStart && Provider.of<Settings>(context, listen: false).startWithAddMeasurementPage) {
       SchedulerBinding.instance.addPostFrameCallback((_) {
@@ -40,20 +34,20 @@ class AppHome extends StatelessWidget {
     return Scaffold(
       body: OrientationBuilder(
         builder: (context, orientation) {
-        if (orientation == Orientation.landscape && MediaQuery.of(context).size.height < 500) {
+        if (orientation == Orientation.landscape) {
           return MeasurementGraph(
             height: MediaQuery.of(context).size.height,
           );
         }
         return Center(
           child: Container(
-            padding: padding,
+            // TODO: utilize more of the screen width
+            padding: const EdgeInsets.only(left: 10, right: 10, bottom: 15, top: 30),
             child: Consumer<Settings>(
               builder: (context, settings, child) {
                 return Column(children: [
                   const MeasurementGraph(),
                   Expanded(
-                    flex: 50,
                     child: (settings.useLegacyList) ?
                       LegacyMeasurementsList(context) :
                       const MeasurementList()

--- a/lib/screens/statistics.dart
+++ b/lib/screens/statistics.dart
@@ -89,7 +89,7 @@ class StatisticsPage extends StatelessWidget {
                   // Time-Resolved Metrics
                   Statistic(
                     caption: Text(AppLocalizations.of(context)!.timeResolvedMetrics),
-                    child: (() {
+                    child: () {
                       final data = analyzer.allAvgsRelativeToDaytime;
                       const opacity = 0.5;
                       return SizedBox(
@@ -133,7 +133,7 @@ class StatisticsPage extends StatelessWidget {
                           ),
                         ),
                       );
-                    })(),
+                    }(),
                   ),
                 ],
               );
@@ -161,6 +161,9 @@ class StatisticsPage extends StatelessWidget {
 class Statistic extends StatelessWidget {
   final Widget caption;
   final Widget child;
+  /// Reduce the padding at the sites, which allows putting it in rows.
+  ///
+  /// TODO: should not depend on property and padding should be added outside of Statistic
   final bool smallEdges;
 
   const Statistic({super.key, required this.caption, required this.child, this.smallEdges = false});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -683,7 +683,7 @@ packages:
     source: hosted
     version: "2.5.0"
   sqflite_common_ffi:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: sqflite_common_ffi
       sha256: "0d5cc1be2eb18400ac6701c31211d44164393aa75886093002ecdd947be04f93"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -33,7 +33,6 @@ dependencies:
   badges: ^3.1.1
   flutter_markdown: ^0.6.17
   collection: ^1.17.1
-  sqflite_common_ffi: ^2.3.0
   restart_app: ^1.2.1
 
 dev_dependencies:
@@ -42,6 +41,7 @@ dev_dependencies:
   file: any
   flutter_lints: ^2.0.0
   mockito: ^5.4.1
+  sqflite_common_ffi: ^2.3.0
 
 flutter:
   uses-material-design: true

--- a/test/model/bood_pressure_test.dart
+++ b/test/model/bood_pressure_test.dart
@@ -1,6 +1,7 @@
 import 'package:blood_pressure_app/model/blood_pressure.dart';
 import 'package:blood_pressure_app/model/ram_only_implementations.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart';
 import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 void main() {
@@ -22,22 +23,24 @@ void main() {
   });
 
   group('BloodPressureModel', () {
-    // setup db path
-    databaseFactory = databaseFactoryFfi;
+    setUpAll(() {
+      sqfliteFfiInit();
+      databaseFactory = databaseFactoryFfi;
+    });
 
     test('should initialize', () async {
       expect(() async {
-        await BloodPressureModel.create(dbPath: '/tmp/bp_test/should_init');
+        await BloodPressureModel.create(dbPath: join(inMemoryDatabasePath, 'BPMShouldInit.db'));
       }, returnsNormally);
     });
     test('should start empty', () async {
-      var m = await BloodPressureModel.create(dbPath: '/tmp/bp_test/should_start_empty');
+      var m = await BloodPressureModel.create(dbPath: join(inMemoryDatabasePath, 'BPMShouldStartEmpty.db'));
 
       expect((await m.getInTimeRange(DateTime.fromMillisecondsSinceEpoch(1), DateTime.now())).length, 0);
     });
 
     test('should notify when adding entries', () async {
-      var m = await BloodPressureModel.create(dbPath: '/tmp/bp_test/should_notify_when_add');
+      var m = await BloodPressureModel.create(dbPath: join(inMemoryDatabasePath, 'BPMShouldNotifyWhenAdding.db'));
 
       int listenerCalls = 0;
       m.addListener(() {
@@ -52,7 +55,7 @@ void main() {
     });
 
     test('should return entries as added', () async {
-      var m = await BloodPressureModel.create(dbPath: '/tmp/bp_test/should_return_as_added');
+      var m = await BloodPressureModel.create(dbPath: join(inMemoryDatabasePath, 'BPMShouldReturnAddedEntries.db'));
 
       var r = BloodPressureRecord(DateTime.fromMillisecondsSinceEpoch(31415926), -172, 10000, 0,
           "((V⍳V)=⍳⍴V)/V←,V    ⌷←⍳→⍴∆∇⊃‾⍎⍕⌈๏ แผ่นดินฮั่นเABCDEFGHIJKLMNOPQRSTUVWXYZ /0123456789abcdefghijklmnopqrstuvwxyz £©µÀÆÖÞßéöÿ–—‘“”„†•…‰™œŠŸž€ ΑΒΓΔΩαβγδω АБВГДабвг, \n \t д∀∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂӥẄɐː⍎אԱა");
@@ -71,12 +74,12 @@ void main() {
     });
 
     test('should save and load between objects/sessions', () async {
-      var m = await BloodPressureModel.create(dbPath: '/tmp/bp_test/should_store_between_sessions');
+      var m = await BloodPressureModel.create(dbPath: join(inMemoryDatabasePath, 'BPMShouldPersist.db'));
       var r = BloodPressureRecord(DateTime.fromMillisecondsSinceEpoch(31415926), -172, 10000, 0,
           "((V⍳V)=⍳⍴V)/V←,V    ⌷←⍳→⍴∆∇⊃‾⍎⍕⌈๏ แผ่นดินฮั่นเABCDEFGHIJKLMNOPQRSTUVWXYZ /0123456789abcdefghijklmnopqrstuvwxyz £©µÀÆÖÞßéöÿ–—‘“”„†•…‰™œŠŸž€ ΑΒΓΔΩαβγδω АБВГДабвг, \n \t д∀∂∈ℝ∧∪≡∞ ↑↗↨↻⇣ ┐┼╔╘░►☺♀ ﬁ�⑀₂ἠḂӥẄɐː⍎אԱა");
       await m.add(r);
 
-      var m2 = await BloodPressureModel.create(dbPath: '/tmp/bp_test/should_store_between_sessions');
+      var m2 = await BloodPressureModel.create(dbPath: join(inMemoryDatabasePath, 'BPMShouldPersist.db'));
       var res = (await m2.getInTimeRange(DateTime.fromMillisecondsSinceEpoch(1), DateTime.now())).first;
 
       expect(res.creationTime, r.creationTime);
@@ -87,7 +90,7 @@ void main() {
     });
 
     test('should delete', () async {
-      var m = await BloodPressureModel.create(dbPath: '/tmp/bp_test/should_delete');
+      var m = await BloodPressureModel.create(dbPath: join(inMemoryDatabasePath, 'BPMShouldDelete.db'));
 
       await m.add(BloodPressureRecord(DateTime.fromMillisecondsSinceEpoch(758934), 123, 87, 65, ';)'));
       expect((await m.getInTimeRange(DateTime.fromMillisecondsSinceEpoch(1), DateTime.now())).length, 1);


### PR DESCRIPTION
Desktop support wasn't continued early in development. This PR removes the dead legacy code and removes the desktop sqflite dependency.

This causes a reduction of app size by 0.2MB.

It also fixes a minor bug where the export of PDF files with a title would not work when no data is present.