### PR TITLE
[Feature] Themed / Monochrome icon support

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
    <application
         android:label="blood pressure app"
         android:name="${applicationName}"
-        android:icon="@mipmap/ic_launcher">
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/drawable-v21/ic_launcher_monochrome.xml
+++ b/android/app/src/main/res/drawable-v21/ic_launcher_monochrome.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M42.79,34.29 L31.73,40.44 30,44.36l2.84,7.8 1.02,1.72 20.01,19.82 5.03,-4.76 -19.95,-19.88 -0.15,0.07 -1.39,-3.86 6.66,-3.69 9.73,9.82 4.76,-4.77 -0.1,-0.1 3.97,-3.77 6.08,0.3h-0.13l2.8,3.34 0.1,0.05 -9.4,9.73 5.53,4.34L78,49.5l-0.09,-4.99 -6,-8.2 -3,-1.71 -8.25,0.98 -3.14,2.81 -3.45,3.57 -7.06,-7.35z"/>
+</vector>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/android:white"/>
+    <foreground android:drawable="@drawable/icon"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/android:white"/>
+    <foreground android:drawable="@drawable/icon"/>
+    <monochrome android:drawable="@drawable/ic_launcher_monochrome"/>
+</adaptive-icon>


### PR DESCRIPTION


### Blue, Dark Theme

![scr2_blue_dark](https://github.com/NobodyForNothing/blood-pressure-monitor-fl/assets/57289288/173f3f2c-2236-490a-94d2-5d4aa1cd159a)

### Yellow, Light Theme

![scr2_yellow_light](https://github.com/NobodyForNothing/blood-pressure-monitor-fl/assets/57289288/6a57434a-f488-4783-a7d8-e4bfcf71abee)
