### PR TITLE
Add padding to top when using bottom app bar

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -182,11 +182,14 @@ class _AppState extends State<App> {
   }
 
   @override
-  Widget build(BuildContext context) => ConsistentFutureBuilder(
-    future: _loadApp(),
-    onWaiting: const LoadingScreen(),
-    onData: (context, widget) => widget,
-  );
+  Widget build(BuildContext context) {
+    if (_loadedChild != null && _configDB != null && _entryDB != null) return _loadedChild!;
+    return ConsistentFutureBuilder(
+      future: _loadApp(),
+      onWaiting: const LoadingScreen(),
+      onData: (context, widget) => widget,
+    );
+  }
 
   /// Central [MaterialApp] widget of the app that sets the uniform style options.
   Widget _buildAppRoot() => Consumer<Settings>(

--- a/app/lib/components/fullscreen_dialoge.dart
+++ b/app/lib/components/fullscreen_dialoge.dart
@@ -10,7 +10,6 @@ class FullscreenDialoge extends StatelessWidget {
     required this.bottomAppBar,
     this.closeIcon = Icons.close,
     this.actions = const <Widget>[],
-    this.closeCallback,
   });
 
   /// The primary content of the dialoge.
@@ -22,10 +21,6 @@ class FullscreenDialoge extends StatelessWidget {
   ///
   /// Setting this icon to null will hide the button entirely.
   final IconData? closeIcon;
-
-  /// Callback that is called after the user pressed the [closeIcon] but before
-  /// popping the scope.
-  final void Function()? closeCallback;
 
   /// Primary content of the text button at the right end of the app bar.
   ///
@@ -55,7 +50,7 @@ class FullscreenDialoge extends StatelessWidget {
   @override
   Widget build(BuildContext context) => Dialog.fullscreen(
     child: Scaffold(
-      body: body,
+      body: _buildBody(),
       appBar: bottomAppBar ? null : _buildAppBar(context),
       bottomNavigationBar: bottomAppBar ? BottomAppBar(
         color: Colors.transparent,
@@ -84,5 +79,14 @@ class FullscreenDialoge extends StatelessWidget {
         ),
     ],
   );
+
+  Widget? _buildBody() {
+    if (body == null) return null;
+    if (!bottomAppBar) return body;
+    return Padding(
+      padding: const EdgeInsets.only(top: 4.0),
+      child: body,
+    );
+  }
 
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -2,4 +2,4 @@ import 'package:blood_pressure_app/app.dart';
 import 'package:flutter/material.dart';
 
 /// Run the [App].
-void main() => runApp(App());
+void main() => runApp(const App());

--- a/app/test/components/fullscreen_dialoge_test.dart
+++ b/app/test/components/fullscreen_dialoge_test.dart
@@ -1,0 +1,89 @@
+import 'package:blood_pressure_app/components/fullscreen_dialoge.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../util.dart';
+
+void main() {
+  testWidgets('shows passed body and bar', (tester) async {
+    await tester.pumpWidget(materialApp(const FullscreenDialoge(
+      actionButtonText: 'BTN',
+      closeIcon: Icons.access_time,
+      actions: [Text('ACTION')],
+      body: Text('BODY'),
+      bottomAppBar: false,
+    )));
+    expect(find.text('BTN'), findsOneWidget);
+    expect(find.text('BODY'), findsOneWidget);
+    expect(find.text('ACTION'), findsOneWidget);
+    expect(find.byIcon(Icons.access_time), findsOneWidget);
+    expect(find.byIcon(Icons.close), findsNothing);
+  });
+  testWidgets('close button pops scope', (tester) async {
+    int popInvokedCount = 0;
+    await tester.pumpWidget(materialApp(PopScope(
+      onPopInvoked: (_) => popInvokedCount++,
+      child: const FullscreenDialoge(
+        closeIcon: Icons.add,
+        bottomAppBar: false,
+        actionButtonText: null,
+      ),
+    )));
+
+    expect(popInvokedCount, 0);
+    await tester.tap(find.byIcon(Icons.add));
+    expect(popInvokedCount, 1);
+  });
+  testWidgets('action button callback works', (tester) async {
+    int actionCallbackCount = 0;
+    await tester.pumpWidget(materialApp(FullscreenDialoge(
+      actionButtonText: 'BTN',
+      onActionButtonPressed: () => actionCallbackCount++,
+      bottomAppBar: false,
+    )));
+
+    expect(actionCallbackCount, 0);
+    await tester.tap(find.text('BTN'));
+    expect(actionCallbackCount, 1);
+    await tester.tap(find.text('BTN'));
+    expect(actionCallbackCount, 2);
+  });
+  testWidgets('app bar is positioned according to bottomAppBar', (tester) async {
+    await tester.pumpWidget(materialApp(const FullscreenDialoge(
+      closeIcon: Icons.add,
+      bottomAppBar: false,
+      actionButtonText: null,
+    )));
+    expect(find.byType(BottomAppBar), findsNothing);
+    expect(tester.getTopLeft(find.byType(AppBar)), tester.getTopLeft(find.byType(FullscreenDialoge)));
+    final double topAppBarYPos = tester.getTopLeft(find.byType(AppBar)).dy;
+
+    await tester.pumpWidget(materialApp(const FullscreenDialoge(
+      closeIcon: Icons.add,
+      bottomAppBar: true,
+      actionButtonText: null,
+    )));
+    expect(tester.getBottomRight(find.byType(BottomAppBar)), tester.getBottomRight(find.byType(FullscreenDialoge)));
+    
+    expect(tester.getTopLeft(find.byType(AppBar)).dy, greaterThan(topAppBarYPos));
+  });
+  testWidgets('bottomAppBar adds 4 units of padding to the top', (tester) async {
+    await tester.pumpWidget(materialApp(const FullscreenDialoge(
+      closeIcon: Icons.add,
+      bottomAppBar: false,
+      actionButtonText: null,
+      body: Text('A'),
+    )));
+    final double bodyStart = tester.getTopLeft(find.text('A')).dy - tester.getBottomRight(find.byType(AppBar)).dy;
+
+    await tester.pumpWidget(materialApp(const FullscreenDialoge(
+      closeIcon: Icons.add,
+      bottomAppBar: true,
+      actionButtonText: null,
+      body: Text('A'),
+    )));
+
+    expect(tester.getTopLeft(find.text('A')).dy, greaterThan(bodyStart));
+    expect(tester.getTopLeft(find.text('A')).dy, bodyStart + 4.0);
+  });
+}


### PR DESCRIPTION
fixes #232

- add 4 units of padding to the top of dialoges when using bottom app bars
- fixes hot reload for faster dev
- removes unused close callback functionality from fullscreen dialoge
- adds tests for existing and new features of fullscreen dialoge