### PR TITLE
Allow medicine intake export and import

### DIFF
--- a/app/lib/features/export_import/export_button_bar.dart
+++ b/app/lib/features/export_import/export_button_bar.dart
@@ -77,6 +77,7 @@ class ExportButtonBar extends StatelessWidget {
                     final converter = CsvConverter(
                       Provider.of<CsvExportSettings>(context, listen: false),
                       Provider.of<ExportColumnsManager>(context, listen: false),
+                      await RepositoryProvider.of<MedicineRepository>(context).getAll(),
                     );
                     final importedRecords = await showImportPreview(
                       context,
@@ -189,6 +190,7 @@ void performExport(BuildContext context, [AppLocalizations? localizations]) asyn
       final csvConverter = CsvConverter(
         Provider.of<CsvExportSettings>(context, listen: false),
         Provider.of<ExportColumnsManager>(context, listen: false),
+        await RepositoryProvider.of<MedicineRepository>(context).getAll(),
       );
       final csvString = csvConverter.create(await _getEntries(context));
       final data = Uint8List.fromList(utf8.encode(csvString));

--- a/app/lib/features/export_import/import_preview_dialoge.dart
+++ b/app/lib/features/export_import/import_preview_dialoge.dart
@@ -56,7 +56,9 @@ class _ImportPreviewDialogeState extends State<ImportPreviewDialoge> {
 
   void _updateBanner() {
     if (_showingError) {
-      _showingError = false;
+      setState(() {
+        _showingError = false;
+      });
       messenger.removeCurrentMaterialBanner();
     }
     final err = _actor.attemptParse().error;
@@ -66,7 +68,9 @@ class _ImportPreviewDialogeState extends State<ImportPreviewDialoge> {
         content: Text(err.localize(localizations),
           style: TextStyle(color: Theme.of(context).colorScheme.error),),
       ),);
-      _showingError = true;
+      setState(() {
+        _showingError = true;
+      });
     }
   }
 

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -512,5 +512,7 @@
     "deleteAllNotes": "Delete all notes",
     "@deleteAllNotes": {},
     "date": "Date",
-    "@date": {}
+    "@date": {},
+    "intakes": "Medicine intakes",
+    "@intakes": {}
 }

--- a/app/lib/model/export_import/column.dart
+++ b/app/lib/model/export_import/column.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:blood_pressure_app/model/export_import/export_configuration.dart';
 import 'package:blood_pressure_app/model/export_import/import_field_type.dart';
 import 'package:blood_pressure_app/model/export_import/record_formatter.dart';
-import 'package:blood_pressure_app/model/storage/convert_util.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:health_data_store/health_data_store.dart';
 
@@ -89,28 +88,25 @@ class NativeColumn extends ExportColumn {
       return null;
     }
   );
-  // TODO: add to default export columns, use during importing
   static final NativeColumn intakes = NativeColumn._create(
       'intakes',
       RowDataFieldType.intakes,
-        (_, __, intakes) => intakes
-            .map((i) => '${i.medicine.designation}(${i.dosis.mg})')
-            .join('|'),
-        (String pattern) {
-          if (pattern.isEmpty) return [];
-          final intakes = [];
-          for (final e in pattern.split('|')) {
-            final es = e.split('(');
-            if (es.length < 2) return null;
-            final [med, dosisStr, ...] = es;
-            final dosis = ConvertUtil.parseDouble(dosisStr.replaceAll(')', ''));
-            if (dosis == null) return null;
-            intakes.add((med, dosis));
-            return intakes;
-          }
-          final value = int.tryParse(pattern);
-          return value;
+      (_, __, intakes) => intakes
+        .map((i) => '${i.medicine.designation}(${i.dosis.mg})')
+        .join('|'),
+      (String pattern) {
+        final intakes = [];
+        for (final e in pattern.split('|')) {
+          final es = e.split('(');
+          if (es.length < 2) return null;
+          final [med, dosisStr, ...] = es;
+          final dosis = double.tryParse(dosisStr.replaceAll(')', ''));
+          if (dosis == null) return null;
+          intakes.add((med, dosis));
         }
+        return intakes;
+      }
+
   );
   
   final String _csvTitle;

--- a/app/lib/model/export_import/column.dart
+++ b/app/lib/model/export_import/column.dart
@@ -89,24 +89,23 @@ class NativeColumn extends ExportColumn {
     }
   );
   static final NativeColumn intakes = NativeColumn._create(
-      'intakes',
-      RowDataFieldType.intakes,
-      (_, __, intakes) => intakes
-        .map((i) => '${i.medicine.designation}(${i.dosis.mg})')
-        .join('|'),
-      (String pattern) {
-        final intakes = [];
-        for (final e in pattern.split('|')) {
-          final es = e.split('(');
-          if (es.length < 2) return null;
-          final [med, dosisStr, ...] = es;
-          final dosis = double.tryParse(dosisStr.replaceAll(')', ''));
-          if (dosis == null) return null;
-          intakes.add((med, dosis));
-        }
-        return intakes;
+    'intakes',
+    RowDataFieldType.intakes,
+    (_, __, intakes) => intakes
+      .map((i) => '${i.medicine.designation}(${i.dosis.mg})')
+      .join('|'),
+    (String pattern) {
+      final intakes = [];
+      for (final e in pattern.split('|')) {
+        final es = e.split('(');
+        if (es.length < 2) return null;
+        final [med, dosisStr, ...] = es;
+        final dosis = double.tryParse(dosisStr.replaceAll(')', ''));
+        if (dosis == null) return null;
+        intakes.add((med, dosis));
       }
-
+      return intakes;
+    }
   );
   
   final String _csvTitle;

--- a/app/lib/model/export_import/column.dart
+++ b/app/lib/model/export_import/column.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:blood_pressure_app/model/export_import/export_configuration.dart';
 import 'package:blood_pressure_app/model/export_import/import_field_type.dart';
 import 'package:blood_pressure_app/model/export_import/record_formatter.dart';
+import 'package:blood_pressure_app/model/storage/convert_util.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';
 import 'package:health_data_store/health_data_store.dart';
 
@@ -23,6 +24,7 @@ class NativeColumn extends ExportColumn {
     notes,
     color,
     needlePin,
+    intakes,
   ];
 
   static final NativeColumn timestampUnixMs = NativeColumn._create(
@@ -87,10 +89,36 @@ class NativeColumn extends ExportColumn {
       return null;
     }
   );
+  // TODO: add to default export columns, use during importing
+  static final NativeColumn intakes = NativeColumn._create(
+      'intakes',
+      RowDataFieldType.intakes,
+        (_, __, intakes) => intakes
+            .map((i) => '${i.medicine.designation}(${i.dosis.mg})')
+            .join('|'),
+        (String pattern) {
+          if (pattern.isEmpty) return [];
+          final intakes = [];
+          for (final e in pattern.split('|')) {
+            final es = e.split('(');
+            if (es.length < 2) return null;
+            final [med, dosisStr, ...] = es;
+            final dosis = ConvertUtil.parseDouble(dosisStr.replaceAll(')', ''));
+            if (dosis == null) return null;
+            intakes.add((med, dosis));
+            return intakes;
+          }
+          final value = int.tryParse(pattern);
+          return value;
+        }
+  );
   
   final String _csvTitle;
   final RowDataFieldType _restoreableType;
   final String Function(BloodPressureRecord record, Note note, List<MedicineIntake> intakes) _encode;
+  /// Function to attempt decoding.
+  ///
+  /// Must either return null or the type indicated by [_restoreableType].
   final Object? Function(String pattern) _decode;
 
   @override

--- a/app/lib/model/export_import/csv_converter.dart
+++ b/app/lib/model/export_import/csv_converter.dart
@@ -167,11 +167,10 @@ class CsvConverter {
       );
       final intakes = intakesData
         ?.map((s) {
-          if (s is! (String, double)) return null;
-          final (designation, weightMg) = s;
-          final med = availableMedicines.firstWhereOrNull((med) => med.designation == designation);
+          assert(s is (String, double));
+          final med = availableMedicines.firstWhereOrNull((med) => med.designation == s.$1);
           if (med == null) return null;
-          return MedicineIntake(time: timestamp, medicine: med, dosis: Weight.mg(weightMg));
+          return MedicineIntake(time: timestamp, medicine: med, dosis: Weight.mg(s.$2));
         })
         .whereNotNull()
         .toList();

--- a/app/lib/model/export_import/export_configuration.dart
+++ b/app/lib/model/export_import/export_configuration.dart
@@ -93,6 +93,7 @@ class ActiveExportColumnConfiguration extends ChangeNotifier {
         NativeColumn.pulse,
         NativeColumn.notes,
         NativeColumn.color,
+        NativeColumn.intakes,
       ],
       ExportImportPreset.myHeart => [
         BuildInColumn.mhDate,

--- a/app/lib/model/export_import/import_field_type.dart
+++ b/app/lib/model/export_import/import_field_type.dart
@@ -19,7 +19,9 @@ enum RowDataFieldType {
   /// Guarantees that a [int] containing a [Color.value] is returned.
   ///
   /// Backwards compatability with [MeasurementNeedlePin] json is maintained.
-  color;
+  color,
+  /// Guarantees [List<(String medicineDesignation, int dosisMg)>] is returned.
+  intakes;
 
   /// Selection of a displayable string from [localizations].
   String localize(AppLocalizations localizations) {
@@ -36,6 +38,8 @@ enum RowDataFieldType {
         return localizations.notes;
       case RowDataFieldType.color:
         return localizations.color;
+      case RowDataFieldType.intakes:
+        return localizations.intakes;
     }
   }
 }

--- a/app/lib/model/export_import/import_field_type.dart
+++ b/app/lib/model/export_import/import_field_type.dart
@@ -20,7 +20,7 @@ enum RowDataFieldType {
   ///
   /// Backwards compatability with [MeasurementNeedlePin] json is maintained.
   color,
-  /// Guarantees [List<(String medicineDesignation, int dosisMg)>] is returned.
+  /// Guarantees [List<(String medicineDesignation, double dosisMg)>] is returned.
   intakes;
 
   /// Selection of a displayable string from [localizations].

--- a/app/lib/model/export_import/record_formatter.dart
+++ b/app/lib/model/export_import/record_formatter.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 
 import 'package:blood_pressure_app/model/blood_pressure/needle_pin.dart';
+import 'package:blood_pressure_app/model/export_import/column.dart';
 import 'package:blood_pressure_app/model/export_import/import_field_type.dart';
 import 'package:function_tree/function_tree.dart';
 import 'package:health_data_store/health_data_store.dart';
@@ -65,6 +66,8 @@ class ScriptedFormatter implements Formatter {
         } on TypeError {
           return null;
         }
+      case RowDataFieldType.intakes:
+        return NativeColumn.intakes.decode(text);
     }}();
     if (value != null) return (restoreAbleType!, value);
     return null;

--- a/app/test/features/bluetooth/mock/fake_device.dart
+++ b/app/test/features/bluetooth/mock/fake_device.dart
@@ -70,7 +70,7 @@ class FakeDevice implements BluetoothDevice {
   }
 
   @override
-  Future<void> disconnect({int timeout = 35, bool queue = true}) async {
+  Future<void> disconnect({int timeout = 35, bool queue = true, int androidDelay = 2000,}) async {
     print('CALLED DISCONNECT:');
     debugPrintStack();
     _connected = false;

--- a/app/test/model/export_import/csv_converter_test.dart
+++ b/app/test/model/export_import/csv_converter_test.dart
@@ -15,13 +15,13 @@ import 'record_formatter_test.dart';
 
 void main() {
   test('should create csv string bigger than 0', () {
-    final converter = CsvConverter(CsvExportSettings(), ExportColumnsManager());
+    final converter = CsvConverter(CsvExportSettings(), ExportColumnsManager(), []);
     final csv = converter.create(createRecords());
     expect(csv.length, isNonZero);
   });
 
   test('should create first line', () {
-    final converter = CsvConverter(CsvExportSettings(), ExportColumnsManager());
+    final converter = CsvConverter(CsvExportSettings(), ExportColumnsManager(), []);
     final csv = converter.create([]);
     final columns = CsvExportSettings().exportFieldsConfiguration.getActiveColumns(ExportColumnsManager());
     expect(csv, stringContainsInOrder(columns.map((e) => e.csvTitle).toList()));
@@ -29,8 +29,9 @@ void main() {
 
   test('should not create first line when setting is off', () {
     final converter = CsvConverter(
-        CsvExportSettings(exportHeadline: false),
-        ExportColumnsManager(),
+      CsvExportSettings(exportHeadline: false),
+      ExportColumnsManager(),
+      [],
     );
     final csv = converter.create([]);
     final columns = CsvExportSettings().exportFieldsConfiguration.getActiveColumns(ExportColumnsManager());
@@ -38,7 +39,7 @@ void main() {
   });
 
   test('should be able to recreate records from csv in default configuration', () {
-    final converter = CsvConverter(CsvExportSettings(), ExportColumnsManager());
+    final converter = CsvConverter(CsvExportSettings(), ExportColumnsManager(), []);
     final initialRecords = createRecords();
     final csv = converter.create(initialRecords);
     final parsedRecords = converter.parse(csv).getOr(failParse);
@@ -57,8 +58,9 @@ void main() {
     final text = File('test/model/export_import/exported_formats/incomplete_export.csv').readAsStringSync();
 
     final converter = CsvConverter(
-        CsvExportSettings(),
-        ExportColumnsManager(),
+      CsvExportSettings(),
+      ExportColumnsManager(),
+      [],
     );
     final parsed = converter.parse(text);
     final records = parsed.getOr(failParse);
@@ -95,8 +97,9 @@ void main() {
     final text = File('test/model/export_import/exported_formats/v1.0.csv').readAsStringSync();
 
     final converter = CsvConverter(
-        CsvExportSettings(),
-        ExportColumnsManager(),
+      CsvExportSettings(),
+      ExportColumnsManager(),
+      [],
     );
     final parsed = converter.parse(text);
     final records = parsed.getOr(failParse);
@@ -122,8 +125,9 @@ void main() {
     final text = File('test/model/export_import/exported_formats/v1.1.0').readAsStringSync();
 
     final converter = CsvConverter(
-        CsvExportSettings(),
-        ExportColumnsManager(),
+      CsvExportSettings(),
+      ExportColumnsManager(),
+      [],
     );
     final parsed = converter.parse(text);
     final records = parsed.getOr(failParse);
@@ -149,8 +153,9 @@ void main() {
     final text = File('test/model/export_import/exported_formats/v1.4.0.CSV').readAsStringSync();
 
     final converter = CsvConverter(
-        CsvExportSettings(),
-        ExportColumnsManager(),
+      CsvExportSettings(),
+      ExportColumnsManager(),
+      [],
     );
     final parsed = converter.parse(text);
     final records = parsed.getOr(failParse);
@@ -183,8 +188,9 @@ void main() {
     final text = File('test/model/export_import/exported_formats/v1.5.1.csv').readAsStringSync();
 
     final converter = CsvConverter(
-        CsvExportSettings(),
-        ExportColumnsManager(),
+      CsvExportSettings(),
+      ExportColumnsManager(),
+      [],
     );
     final parsed = converter.parse(text);
     final records = parsed.getOr(failParse);
@@ -220,8 +226,9 @@ void main() {
     final text = File('test/model/export_import/exported_formats/v1.5.7.csv').readAsStringSync();
 
     final converter = CsvConverter(
-        CsvExportSettings(),
-        ExportColumnsManager(),
+      CsvExportSettings(),
+      ExportColumnsManager(),
+      [],
     );
     final parsed = converter.parse(text);
     final records = parsed.getOr(failParse);
@@ -260,6 +267,7 @@ void main() {
     final converter = CsvConverter(
       CsvExportSettings(),
       ExportColumnsManager(),
+      [],
     );
     final parsed = converter.parse(text);
     final records = parsed.getOr(failParse);
@@ -312,6 +320,7 @@ void main() {
         )
       ),
       cols,
+      [],
     );
     final parsed = converter.parse(text);
 


### PR DESCRIPTION
closes #326

Medicine intakes can now be exported to CSV of the format `MedName1(123.0)|MedName2(456.0)` with the number representing dosis in mg. Import of that data is possible as long as there is a medicine with matching designation.

The alternative approach with columns for each medicine wasn't compatible with the column selection logic.