### PR TITLE
Reintroduce desktop support

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -17,7 +17,7 @@ import 'package:health_data_store/health_data_store.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:path/path.dart';
 import 'package:provider/provider.dart';
-import 'package:sqflite/sqflite.dart';
+import 'package:sqflite_common_ffi/sqflite_ffi.dart';
 
 /// Base class for the entire app.
 ///
@@ -68,6 +68,10 @@ class _AppState extends State<App> {
   /// Load the primary app data asynchronously to allow load animations.
   Future<Widget> _loadApp() async {
     WidgetsFlutterBinding.ensureInitialized();
+    if (Platform.isLinux || Platform.isMacOS || Platform.isWindows) {
+      databaseFactory = databaseFactoryFfi;
+    }
+
     if (_loadedChild != null && _configDB != null && _entryDB != null) return _loadedChild!;
 
     if (widget.forceClearAppDataOnLaunch) {

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -514,5 +514,7 @@
     "date": "Date",
     "@date": {},
     "intakes": "Medicine intakes",
-    "@intakes": {}
+    "@intakes": {},
+    "errFeatureNotSupported": "This feature is not available on this platform.",
+    "@errFeatureNotSupported": {}
 }

--- a/app/lib/model/storage/settings_store.dart
+++ b/app/lib/model/storage/settings_store.dart
@@ -1,5 +1,6 @@
 import 'dart:collection';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:blood_pressure_app/model/blood_pressure/medicine/medicine.dart';
 import 'package:blood_pressure_app/model/blood_pressure/pressure_unit.dart';
@@ -395,7 +396,7 @@ class Settings extends ChangeNotifier {
 
   bool _bleInput = true;
   /// Whether to show bluetooth input on add measurement page.
-  bool get bleInput => _bleInput;
+  bool get bleInput => (Platform.isAndroid || Platform.isIOS || Platform.isMacOS) && _bleInput;
   set bleInput(bool value) {
     _bleInput = value;
     notifyListeners();

--- a/app/lib/screens/settings_screen.dart
+++ b/app/lib/screens/settings_screen.dart
@@ -155,11 +155,15 @@ class SettingsPage extends StatelessWidget {
               ),
               SwitchListTile(
                 value: settings.bleInput,
-                onChanged: (value) {
-                  settings.bleInput = value;
-                },
+                onChanged: (Platform.isAndroid || Platform.isIOS || Platform.isMacOS)
+                  ? (value) { settings.bleInput = value; }
+                  : null,
                 secondary: const Icon(Icons.bluetooth),
-                title: Text(localizations.bluetoothInput),),
+                title: Text(localizations.bluetoothInput),
+                subtitle: (Platform.isAndroid || Platform.isIOS || Platform.isMacOS)
+                  ? null
+                  : Text(localizations.errFeatureNotSupported),
+              ),
               SwitchListTile(
                 value: settings.allowManualTimeInput,
                 onChanged: (value) {

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -918,7 +918,7 @@ packages:
     source: hosted
     version: "2.5.4"
   sqflite_common_ffi:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: sqflite_common_ffi
       sha256: "4d6137c29e930d6e4a8ff373989dd9de7bac12e3bc87bce950f6e844e8ad3bb5"

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -38,6 +38,9 @@ dependencies:
   fluttertoast: ^8.2.6
   app_settings: ^5.1.1
 
+  # desktop only
+  sqflite_common_ffi: ^2.3.3
+
 dev_dependencies:
   integration_test:
     sdk: flutter
@@ -46,7 +49,6 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^4.0.0
   mockito: ^5.4.4
-  sqflite_common_ffi: ^2.3.3
   translations_cleaner: ^0.0.5
   build_runner: ^2.4.12
   bloc_test: ^9.1.7


### PR DESCRIPTION
closes #325

Due to flutters architecture enabling desktop support is rather simple. There is no impact on the normal app size due to optimizations done by the compiler. 

This should make development faster.