### PR TITLE
Unify input dialoge text style

### DIFF
--- a/app/lib/features/input/add_measurement_dialoge.dart
+++ b/app/lib/features/input/add_measurement_dialoge.dart
@@ -160,6 +160,7 @@ class _AddEntryDialogeState extends State<AddEntryDialoge> {
       focusNode: focusNode,
       onSaved: onSaved,
       controller: controller,
+      style: Theme.of(context).textTheme.bodyLarge,
       inputFormatters: [FilteringTextInputFormatter.digitsOnly],
       onChanged: (String value) {
         if (value.isNotEmpty
@@ -321,10 +322,10 @@ class _AddEntryDialogeState extends State<AddEntryDialoge> {
             ),
             InputDecorator(
               decoration: InputDecoration(
-                contentPadding: EdgeInsets.zero
+                contentPadding: EdgeInsets.zero,
               ),
               child: ColorSelectionListTile(
-                title: Text(localizations.color),
+                title: Text(localizations.color, style: Theme.of(context).textTheme.bodyLarge,),
                 onMainColorChanged: (Color value) => setState(() {
                   color = (value == Colors.transparent) ? null : value;
                 }),
@@ -346,10 +347,10 @@ class _AddEntryDialogeState extends State<AddEntryDialoge> {
                             for (final med in widget.availableMeds)
                               DropdownMenuItem(
                                 value: med,
-                                child: Text(med.designation),
+                                child: Text(med.designation, style: Theme.of(context).textTheme.bodyLarge,),
                               ),
                             DropdownMenuItem(
-                              child: Text(localizations.noMedication),
+                              child: Text(localizations.noMedication, style: Theme.of(context).textTheme.bodyLarge,),
                             ),
                           ],
                           onChanged: (v) {
@@ -376,6 +377,7 @@ class _AddEntryDialogeState extends State<AddEntryDialoge> {
                             decoration: InputDecoration(
                               labelText: localizations.dosis,
                             ),
+                            style: Theme.of(context).textTheme.bodyLarge,
                             focusNode: dosisFocusNote,
                             keyboardType: TextInputType.number,
                             onChanged: (value) {

--- a/app/lib/features/input/forms/date_time_form.dart
+++ b/app/lib/features/input/forms/date_time_form.dart
@@ -64,7 +64,10 @@ class _DateTimeFormState extends State<DateTimeForm> {
 
   Widget _buildInput(String content, void Function() onTap, String label) => Expanded(
     child: InputDecorator(
-      child: GestureDetector(onTap: onTap, child: Text(content)),
+      child: GestureDetector(
+        onTap: onTap,
+        child: Text(content, style: Theme.of(context).textTheme.bodyLarge)
+      ),
       decoration: InputDecoration(
         labelText: label,
       ),


### PR DESCRIPTION
The font for medication selection used to be too wide and colors of different input fields used to slightly mismatch. Not using bodyLarge style for all inputs. 

```dart
Theme.of(context).textTheme.bodyLarge
```

<details><summary>Sample render</summary>

![correct render](https://github.com/user-attachments/assets/40073b40-ceea-4a6d-b5d7-b1e6b4e76758)

</details>