### PR TITLE
Update goldens in CI

### DIFF
--- a/.github/workflows/app-CI.yml
+++ b/.github/workflows/app-CI.yml
@@ -54,10 +54,11 @@ jobs:
     - name: Update goldens
       id: gold-upd
       if: failure()
-      run: flutter test --update-goldens --fail-fast || echo "FAILED=true" >> $GITHUB_OUTPUT
+      run: flutter test --update-goldens --fail-fast
       working-directory: app
     - name: PR golden changes
-      if: ${{ failure() && steps.gold-upd.outpus.FAILED == 'true' }}
+      # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#example-of-failure-with-conditions
+      if: ${{ failure() && steps.gold-upd.conclusion == 'success' }}
       run: |
         git config user.name "GitHub Action (update goldens)"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/app-CI.yml
+++ b/.github/workflows/app-CI.yml
@@ -65,6 +65,7 @@ jobs:
         git checkout -B action-update-goldens
         export STATUS=$(git status)
         git commit -am "Update goldens"
+        git push
         gh pr create --base main --head action-update-goldens --title "Update goldens" --body "${STATUS}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/app-CI.yml
+++ b/.github/workflows/app-CI.yml
@@ -21,6 +21,7 @@ jobs:
     name: "🧩🧪 Run unit tests"
     runs-on: ubuntu-latest
     permissions:
+      contents: write
       pull-requests: write
     steps:
     - name: Checkout code
@@ -62,11 +63,17 @@ jobs:
       run: |
         git config user.name "GitHub Action (update goldens)"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        
         git checkout -B action-update-goldens
         export STATUS=$(git status)
         git commit -am "Update goldens"
         git push --set-upstream origin action-update-goldens
-        gh pr create --base main --head action-update-goldens --title "Update goldens" --body "${STATUS}"
+        
+        gh pr create \
+          --base main \
+          --head action-update-goldens \
+          --title "Update goldens" \
+          --body "$STATUS"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/app-CI.yml
+++ b/.github/workflows/app-CI.yml
@@ -65,7 +65,7 @@ jobs:
         git checkout -B action-update-goldens
         export STATUS=$(git status)
         git commit -am "Update goldens"
-        gh pr create --base main --head action-update-goldens --title "Update goldens" --body $STATUS
+        gh pr create --base main --head action-update-goldens --title "Update goldens" --body "${STATUS}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/app-CI.yml
+++ b/.github/workflows/app-CI.yml
@@ -20,7 +20,8 @@ jobs:
   unit-test:
     name: "🧩🧪 Run unit tests"
     runs-on: ubuntu-latest
- 
+    permissions:
+      pull-requests: write
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -50,10 +51,22 @@ jobs:
     - name: Run tests
       run: flutter test --coverage
       working-directory: app
-    - uses: actions/upload-artifact@v4
-      with:
-        name: app-coverage
-        path: app/coverage/lcov.info
+    - name: Update goldens
+      id: gold-upd
+      if: failure()
+      run: flutter test --update-goldens --fail-fast || echo "FAILED=true" >> $GITHUB_OUTPUT
+      working-directory: app
+    - name: PR golden changes
+      if: ${{ failure() && steps.gold-upd.outpus.FAILED == 'true' }}
+      run: |
+        git config user.name "GitHub Action (update goldens)"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git checkout -B action-update-goldens
+        export STATUS=${git status}
+        git commit -am "Update goldens"
+        gh pr create --base main --head action-update-goldens --title "Update goldens" --body $STATUS
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 #  Disabled: Integration tests are disabled as emulator setup fails on
 #  GH-actions. Actions images no longer provide enough disk space to create

--- a/.github/workflows/app-CI.yml
+++ b/.github/workflows/app-CI.yml
@@ -65,7 +65,7 @@ jobs:
         git checkout -B action-update-goldens
         export STATUS=$(git status)
         git commit -am "Update goldens"
-        git push
+        git push --set-upstream origin action-update-goldens
         gh pr create --base main --head action-update-goldens --title "Update goldens" --body "${STATUS}"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/app-CI.yml
+++ b/.github/workflows/app-CI.yml
@@ -63,7 +63,7 @@ jobs:
         git config user.name "GitHub Action (update goldens)"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git checkout -B action-update-goldens
-        export STATUS=${git status}
+        export STATUS=$(git status)
         git commit -am "Update goldens"
         gh pr create --base main --head action-update-goldens --title "Update goldens" --body $STATUS
       env:


### PR DESCRIPTION
Unfortunately flutter seems to render slightly different on GitHub CI than locally. To still allow running golden tests in CI a PR gets created for golden changes. This also allows for easy inspections of golden failures.

Sample PR: #391 