### PR TITLE
fix: create database path recursively

### DIFF
--- a/app/lib/model/storage/db/file_settings_loader.dart
+++ b/app/lib/model/storage/db/file_settings_loader.dart
@@ -21,7 +21,7 @@ class FileSettingsLoader implements SettingsLoader {
   /// settings path.
   static Future<FileSettingsLoader> load([String? path]) async {
     path ??= join(await getDatabasesPath(), 'settings');
-    Directory(path).createSync();
+    Directory(path).createSync(recursive: true);
     return FileSettingsLoader._create(path);
   }
 


### PR DESCRIPTION
Tiny fix, while starting the app on Linux the app had a fatal error because by default it creates new databases in the `app/.dart_tool/sqflite_common_ffi/databases/` folder while only `app/.dart_tool` already exists by default