### PR TITLE
docs: Record known working state of Omron BP5150

### DIFF
--- a/docs/bluetooth.md
+++ b/docs/bluetooth.md
@@ -30,6 +30,7 @@ Most devices provide 2 ways to retrieve measurements over bluetooth, but there a
 |HealthForYou by Silvercrest (Type SBM 69)|SBM69| 🔢 | ✅ | ✅ |
 |Omron X4 Smart|X4 Smart| 1️⃣ | ✅🗑️ | ✅ |
 |Omron X2 Smart+|X2 Smart+| 1️⃣ | ? | ? |
+|Omron Bronze BP5150|BLESmart_(long identifier string)| 1️⃣ | ? | ? |
 
 #### Legenda
 


### PR DESCRIPTION
This adds the Omron Bronze (BP5150) to the known working devices documentation.

Much like #583, I'm not sure how to test download mode or disconnection status. My current understanding of the capabilities of the device and how it interacts with synchronization (for both the official proprietary Omron Connect app and this app) is that the user must manually delete records. I think they also start being overwritten if you exceed capacity, but I am unsure. I think that means download mode is unsupported, but it might just be that I've yet to figure out how to do it.

I want to use this space to document a little bit of the process, since I had a hard time figuring out how to get this to work.

Pairing:
- Hold down the Bluetooth button for about 5 seconds. You should see a flashing `P`. This puts the monitor into pairing mode.
- In the app, press the `+`, as if you want to add a new reading.
- Near the top of the entry screen, press the `Bluetooth input` text. You should get four spinning squares on the monitor, and if this is the first time, a pairing request notification.
- Pair and connect from the notification. You do not need to provide access to contacts and call history. In my experience, I had to hit "pair and connect" twice, for some reason.
- Wait until the squares stop spinning and are accompanied by the `OK` icon.
- Once you see the `OK` icon, press the `START/STOP` button on the monitor to turn it off. The spinner in the app will not stop, you can just leave the menu now.

Measuring:
- Open the app and press the `+`, to get to the new reading screen.
- After pressing `START/STOP` to start taking a measurement, press the `Bluetooth input` text.
- A little after the measurement is finished (say 3 minutes tops?) the app should auto fill the reading menu with the information from the monitor. Verify against the device, add any additional information you may want to record, and hit `SAVE`.